### PR TITLE
Take the first line of a multi line where.exe output to find git

### DIFF
--- a/src/metav/git.clj
+++ b/src/metav/git.clj
@@ -26,13 +26,13 @@
 
 (def ^:private find-windows-git
   (memoize
-    (fn []
-      (let [{:keys [exit out err]} (shell/sh "where.exe" "git.exe")]
-        (if-not (zero? exit)
-          (abort (format (str "Can't determine location of git.exe: 'where git.exe' returned %d.\n"
-                                   "stdout: %s\n stderr: %s")
-                              exit out err))
-          (string/trim out))))))
+   (fn []
+     (let [{:keys [exit out err]} (shell/sh "where.exe" "git.exe")]
+       (if-not (zero? exit)
+         (abort (format (str "Can't determine location of git.exe: 'where git.exe' returned %d.\n"
+                             "stdout: %s\n stderr: %s")
+                        exit out err))
+         (first (string/split-lines (string/trim out))))))))
 
 (defn- git-exe []
   (if windows?


### PR DESCRIPTION
Fixes #4 

An easy fix !

Tested working on windows with a two lines where.exe output