### PR TITLE
Bumping edge case when bumping a dirty version.

### DIFF
--- a/src/metav/semver.clj
+++ b/src/metav/semver.clj
@@ -44,7 +44,7 @@
 (let [re #"(\d+)\.(\d+)\.(\d+)"]
   (defn- parse-base [base]
     (log/debug "parse-base(" base ")")
-    (let [[_ major minor patch] (re-matches re base)]
+    (let [[_ major minor patch] (re-find re base)]
       ;(assert (= "0" patch) (str "Non-zero patch level (" patch ") found in SCM base"))
       (mapv #(Integer/parseInt %) [major minor patch]))))
 


### PR DESCRIPTION
Hi,

I came across an uncaught exception while playing with metav. Here is how it works.

Let's say I have a repo setup this way:

- Repo's root
  - `.git`
  - project1
    - `deps.edn`
    - `etc...`
  - project2
    - `deps.edn`
    - `etc...`

Let's say everything is committed in `project1` while some stuff remains uncommitted in `project2`, every project is version `0.1.0`. If I release a patch from `root/project1`, metav will allow the bump from `0.1.0-XXXX-DIRTY` to `0.1.1-DIRTY` creating a tag like `project1-0.1.1-DIRTY`. 

Now if I wanna bump again, when metav creates its `invocation-context`, it parses the previous tag and will end up trying to do something like:
```clojure
(let [[_ major minor patch] (re-matches #"(\d+)\.(\d+)\.(\d+)" "0.1.1-DIRTY")] ;=> [nil nil nil nil]
  (mapv #(Integer/parseInt %) [major minor patch])) ; => throws Integer/parse exception
```

I propose in this PR to change the use of `re-matches` for `re-find`. This way the regex would return the numbers we want. However I am not sure fixing the parsing is the good answer because I am not sure if the possibility of releasing a "DIRTY" version is intended behaviour. 

Cheers,

Jeremy.