### PR TITLE
create an option to have tags without the "v" prefix

### DIFF
--- a/src/metav/cli/display.clj
+++ b/src/metav/cli/display.clj
@@ -13,7 +13,10 @@
          :id :metav.display/output-format
          :parse-fn keyword
          :validate [(partial s/valid? :metav.display/output-format)
-                    "Format must be among: edn, json, tab"]]))
+                    "Format must be among: edn, json, tab"]]
+        [nil "--prefix PREFIX" "version tags without an artifact prefix will have this prefix (use :none for no prefix)"
+         :id :metav/root-prefix
+         :default-desc "v"]))
 
 
 (defn usage [summary]

--- a/src/metav/cli/release.clj
+++ b/src/metav/cli/release.clj
@@ -19,7 +19,10 @@
          :default-desc "false"]
         ["-w" "--without-push" "Execute the release process but without pushing at the end, if you want to control the pushing instant yourself"
          :id :metav.release/without-push
-         :default-desc "false"]))
+         :default-desc "false"]
+        [nil "--prefix PREFIX" "version tags without an artifact prefix will have this prefix (use :none for no prefix)"
+         :id :metav/root-prefix
+         :default-desc "v"]))
 
 ;;----------------------------------------------------------------------------------------------------------------------
 ;; Assembling Release main

--- a/src/metav/domain/pom.clj
+++ b/src/metav/domain/pom.clj
@@ -24,7 +24,8 @@
 
 
 (defn ctxt->group-id [context]
-  (:metav/project-name context))
+  "com.atomist"
+  #_(:metav/project-name context))
 
 
 (defn ctxt->pom-name [context]


### PR DESCRIPTION
I'm working on some projects where the "v" prefix in the tag is breaking some other downstream workflows.  

I was wondering whether it might be a useful addition to make that prefix an option:

So, an example could be:
`clj -m metav.release --prefix "not_v"`
In my case, I wanted the prefix to be an empty string so:
`clj -m metav.release --prefix :none` 
was what I actually wanted to use.

Thanks for the work on this Jeremie!