### PR TITLE
Feature/sync lein project file

### DIFF
--- a/resources-test/dummy-project.clj
+++ b/resources-test/dummy-project.clj
@@ -1,0 +1,2 @@
+(defproject my-group-id/my-artifact-id "0.1.0"
+  :dependencies [[awesome/lib "0.0.1"]])

--- a/src/metav/cli/spit.clj
+++ b/src/metav/cli/spit.clj
@@ -32,6 +32,10 @@
          :id :metav.spit/pom
          :default-desc "false"]
 
+        ["-l" "--lein" "Indicates the spit/release process should update the project.clj file for the project"
+         :id :metav.spit/lein
+         :default-desc "false"]
+
         ["-f" "--formats FORMATS" "Comma-separated list of output formats (clj, cljc, cljs, edn, json)"
          :id :metav.spit/formats
          :parse-fn parse-formats

--- a/src/metav/domain/leningen.clj
+++ b/src/metav/domain/leningen.clj
@@ -1,0 +1,25 @@
+(ns metav.domain.leningen
+  (:require
+    [clojure.string :as string]
+    [clojure.tools.logging :as log]))
+
+(defn sync-lein-version!
+  "Change version in project.clj file for leningen project.
+  Takes the bumped version as parameter.
+
+  Note : Due to regex, we can't read project through clojure.edn/read-string. Replace version by string manipulation instead."
+  [context]
+  (let [{:metav/keys [working-dir version]} context
+        bumped-version (.toString version)
+        project-file-path (str working-dir "/project.clj")
+        content (slurp project-file-path)
+        [defproject+group-artifact+version group-id artifact-name version-to-bump] (re-find #"\(defproject\ ((?:\w|\.|\-)+)\/((?:\w|\/|\-)+) \"([^\"]*)\"" content)
+        bumped-content (string/replace content defproject+group-artifact+version (string/replace defproject+group-artifact+version version-to-bump bumped-version))]
+    (log/debug (str "Bump lein project.clj version in " project-file-path " from " version-to-bump " to " bumped-version))
+    (spit project-file-path bumped-content)
+    (log/debug (str "Lein project.clj version bumped in " project-file-path " from " version-to-bump " to " bumped-version))
+    {:metav.lein/group-id          group-id
+     :metav.lein/artifact-name     artifact-name
+     :metav.lein/previous-version  version-to-bump
+     :metav.lein/version           bumped-version
+     :metav.lein/project-file-path "project.clj"}))

--- a/src/metav/domain/tag.clj
+++ b/src/metav/domain/tag.clj
@@ -9,12 +9,13 @@
 (def DEFAULT-REGEX-MULTIREPO               #"(?<artefactname>.*-.*)-(?<major>.*)\.(?<minor>.*)\.(?<patch>.*)")
 
 (defn format-tag
-  ([context]
-   (format-tag (:metav/tag-format-string context)
+  ([context]                                                ;; FIXME will stackoverflow, what's the intention ?
+   #_(format-tag (:metav/tag-format-string context)
            ;(:metav/tag-parse-re context)
                                         ;[major minor patch distance sha dirty?]
            ;artefact-name full-name definitive-module-name
-           ))
+           )
+   context)
   ([version artefact-name]
    (format-tag DEFAULT-FORMAT-STRING-STANDALONE-REPO artefact-name version))
   ([format-string version artefact-name]

--- a/test/metav/domain/leningen_test.clj
+++ b/test/metav/domain/leningen_test.clj
@@ -1,0 +1,25 @@
+(ns metav.domain.leningen-test
+  (:require [clojure.test :refer [deftest testing]]
+            [clojure.java.shell :as shell]
+            [testit.core :refer [fact =>]]
+            [metav.domain.leningen :refer [sync-lein-version!]]
+            [metav.git-shell :refer [write-dummy-project-clj-in!]]
+            [me.raynes.fs :as fs]))
+
+(deftest sync-lein-version!-test
+  (binding [shell/*sh-dir* "target"]
+    (try
+      (write-dummy-project-clj-in! "lein-project")
+      (testing "Syncing lein project version"
+        (let [bumped-lein-project (sync-lein-version!
+                                    {:metav/version     #metav.domain.version.semver.SemVer{:subversions [0 1 1], :distance 0, :sha "6d45", :dirty? false},
+                                     :metav/working-dir "target/lein-project"})]
+          (fact "returns the group id" (:metav.lein/group-id bumped-lein-project) => "my-group-id")
+          (fact "returns the artifact name" (:metav.lein/artifact-name bumped-lein-project) => "my-artifact-id")
+          (fact "returns the previous version" (:metav.lein/previous-version bumped-lein-project) =>  "0.1.0")
+          (fact "returns the new version" (:metav.lein/version bumped-lein-project) => "0.1.1")
+          (fact "replaces version in project.clj file"
+                (slurp "target/lein-project/project.clj")
+                =>
+                "(defproject my-group-id/my-artifact-id \"0.1.1\"\n  :dependencies [[awesome/lib \"0.0.1\"]])\n")))
+      (finally (fs/delete-dir "lein-project")))))

--- a/test/metav/git_shell.clj
+++ b/test/metav/git_shell.clj
@@ -41,6 +41,7 @@
 
 
 (def deps-edn-path (-> "dummy-deps.edn" io/resource io/file str))
+(def project-clj-path (-> "dummy-project.clj" io/resource io/file str))
 
 
 (defn sh [command]
@@ -88,6 +89,18 @@
                    (->> (apply fs/file))
                    str))
         command (str "cp " deps-edn-path " " dest)]
+    ;(log/debug "will execute: "command)
+    (sh command)))
+
+(defn write-dummy-project-clj-in! [& dirs]
+  (apply mkdir-p! dirs)
+  (let [dest (fs/with-cwd shell/*sh-dir*
+                          (-> dirs
+                              vec
+                              (conj "project.clj")
+                              (->> (apply fs/file))
+                              str))
+        command (str "cp " project-clj-path " " dest)]
     ;(log/debug "will execute: "command)
     (sh command)))
 


### PR DESCRIPTION
sync the version in Leiningen project.clj file while releasing new tag.
Add option `-l` or `--lein` to spit cli. 